### PR TITLE
initial porting work for Ubuntu / Debian

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,3 +6,4 @@ Christer Edwards [christer.edwards@gmail.com]
 
 ## Contributors
 - Chris Wells (authored Bastillefile template format & parser)
+- Jordan Ebisu

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ install:
 .PHONY: uninstall
 uninstall:
 	@echo "Removing Rocinante command"
-	@rm -vf /usr/local/bin/rocinante
+	@rm -vf /usr/bin/rocinante
 	@echo
 	@echo "Removing Bastille sub-commands"
-	@rm -rvf /usr/local/libexec/rocinante
+	@rm -rvf /usr/libexec/rocinante
 	@echo
 	@echo "removing configuration file"
-	@rm -rvf /usr/local/etc/rocinante.conf.sample
+	@rm -rvf /etc/rocinante.conf.sample
 	@echo
 	@echo "You may need to manually remove /usr/local/etc/rocinante.conf if it is no longer needed."

--- a/usr/local/libexec/rocinante/cmd.sh
+++ b/usr/local/libexec/rocinante/cmd.sh
@@ -49,7 +49,7 @@ fi
 ## execute CMD
 sh -c "$@"
 ERROR_CODE="$?"
-info "${ERROR_CODE}"
+warn "${ERROR_CODE}"
 
 echo -e "${COLOR_RESET}"
 return "${ERROR_CODE}"

--- a/usr/local/libexec/rocinante/common.sh
+++ b/usr/local/libexec/rocinante/common.sh
@@ -58,7 +58,7 @@ error_exit() {
 }
 
 info() {
-    echo -e "${COLOR_GREEN}$*${COLOR_RESET}"
+    echo "${COLOR_GREEN}$*${COLOR_RESET}"
 }
 
 warn() {


### PR DESCRIPTION
This patch updates the Makefile (we should make it smart enough to handle both platforms)

Initially settling on /usr/libexec/rocinante for the core files with /usr/bin/rocinante for binary.

Includes a couple other small fixes.